### PR TITLE
Sync optimizations

### DIFF
--- a/data/sqldb.go
+++ b/data/sqldb.go
@@ -38,9 +38,6 @@ func btoi(b bool) int {
 	return 0
 }
 
-func (s *SqlStorage) submissionThread() {
-
-}
 func (s *SqlStorage) Submit(ctx context.Context, data map[string]senml.Pack, series map[string]*registry.TimeSeries) (err error) {
 	s.updateMutex.Lock()
 	defer s.updateMutex.Unlock()

--- a/grpc_interceptor.go
+++ b/grpc_interceptor.go
@@ -32,14 +32,10 @@ func StreamLogInterceptor() grpc.StreamServerInterceptor {
 
 		err := handler(srv, stream)
 
-		if err != nil || common.Debug {
-			var streamText string
-			if info.IsClientStream {
-				streamText = "cli"
-			} else {
-				streamText = "srv"
-			}
-			log.Printf("%s gRPC %s stream %s err:%v", info.FullMethod, streamText, time.Since(start), err)
+		if err != nil {
+			log.Printf("%s gRPC stream %s err: %s", info.FullMethod, time.Since(start), err)
+		} else if common.Debug {
+			log.Printf("%s gRPC stream %s", info.FullMethod, time.Since(start))
 		}
 
 		return err

--- a/registry/controller.go
+++ b/registry/controller.go
@@ -29,6 +29,10 @@ func (c Controller) getLastModifiedTime() (time.Time, common.Error) {
 }
 
 func (c Controller) Add(ts TimeSeries) (*TimeSeries, common.Error) {
+	err := validateCreation(ts)
+	if err != nil {
+		return nil, &common.BadRequestError{S: err.Error()}
+	}
 	addedTs, err := c.s.add(ts)
 	if err != nil {
 		if errors.Is(err, ErrConflict) {

--- a/registry/leveldb.go
+++ b/registry/leveldb.go
@@ -76,11 +76,6 @@ func (s *LevelDBStorage) close() error {
 func (s *LevelDBStorage) add(ts TimeSeries) (*TimeSeries, error) {
 	s.wg.Add(1)
 	defer s.wg.Done()
-	err := validateCreation(ts, s.conf)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrBadRequest, err)
-	}
-
 	// Convert to json bytes
 	tsBytes, err := ts.MarshalSensitiveJSON()
 	if err != nil {

--- a/registry/memory.go
+++ b/registry/memory.go
@@ -36,10 +36,6 @@ func NewMemoryStorage(conf common.RegConf, listeners ...EventListener) Storage {
 }
 
 func (ms *MemoryStorage) add(ts TimeSeries) (*TimeSeries, error) {
-	err := validateCreation(ts, ms.conf)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrBadRequest, err)
-	}
 	ms.mutex.RLock()
 	defer ms.mutex.RUnlock()
 
@@ -53,7 +49,7 @@ func (ms *MemoryStorage) add(ts TimeSeries) (*TimeSeries, error) {
 	ms.resources[ts.Name] = ts.Name
 
 	// Send a create event
-	err = ms.event.created(&ts)
+	err := ms.event.created(&ts)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/validation.go
+++ b/registry/validation.go
@@ -21,7 +21,7 @@ import (
 // type: mandatory, fixed
 // format: mandatory
 
-func validateCreation(ts TimeSeries, conf common.RegConf) error {
+func validateCreation(ts TimeSeries) error {
 	var e validationError
 
 	//validate name


### PR DESCRIPTION
The major changes are :
1. Avoiding Sql injections whenever possible
2. The server will not hang when the gRPC client is slow or stuck due to pub such channel being full
3. Sql `data base is locked` error fix by adding a mutex to write operations. Read operations are not protected considering the WAL is used
4. Improving logs in grpc interceptor
5. Validating logic for the time series creation in registry is moved up to the controller level. Earlier it was in storage level causing the code duplication. Morever, it doesn't belong there.
